### PR TITLE
Removed download env-file default

### DIFF
--- a/scripts/download_confluence.py
+++ b/scripts/download_confluence.py
@@ -713,7 +713,7 @@ Examples:
     )
 
     parser.add_argument('page_ids', nargs='*', help='Page IDs to download')
-    parser.add_argument('--env-file', default='.env', help='Path to .env file (default: .env)')
+    parser.add_argument('--env-file', default=None, help='Path to specific .env file (optional)')
     parser.add_argument('--output-dir', help='Output directory (overrides .env CONFLUENCE_OUTPUT_DIR)')
     parser.add_argument('--download-children', action='store_true', help='Download child pages to subdirectories')
     parser.add_argument('--save-html', action='store_true', help='Save intermediate HTML files for debugging')


### PR DESCRIPTION
This pull request makes a minor update to the argument parsing in the `scripts/download_confluence.py` script. The change updates the behavior of the `--env-file` argument so that it is now optional and does not default to `.env`.

- Changed the `--env-file` argument in the `main` function to be optional (defaulting to `None` instead of `.env`), clarifying that specifying a .env file is now optional, this way if environment variables are set it works.